### PR TITLE
BUGFIX: Check context property for being of NodeInterface

### DIFF
--- a/Classes/Aspect/Runtime/FusionRuntimeAspect.php
+++ b/Classes/Aspect/Runtime/FusionRuntimeAspect.php
@@ -39,8 +39,7 @@ class FusionRuntimeAspect
     public function extendContextArrayWithMetaDataRootNode(JoinPointInterface $joinPoint)
     {
         $contextArray = $joinPoint->getMethodArgument('contextArray');
-        if (isset($contextArray['node'])) {
-            /** @var NodeInterface $node */
+        if (isset($contextArray['node']) && $contextArray['node'] instanceof NodeInterface) {
             $node = $contextArray['node'];
             $contextArray[MetaDataRepository::METADATA_ROOT_NODE_NAME] = $this->nodeService->findOrCreateMetaDataRootNode($node->getContext());
             $joinPoint->setMethodArgument('contextArray', $contextArray);


### PR DESCRIPTION
When `!$contextArray['node'] instanceof NodeInterface`, we'd try to call `getContext()` on f.e. a `string`, which obviously won't work.

I stumbled on this while trying out https://github.com/aertmann/history.