### PR TITLE
BUGFIX: Persist new meta data node on asset creation

### DIFF
--- a/Classes/Mapper/ContentRepositoryMapper.php
+++ b/Classes/Mapper/ContentRepositoryMapper.php
@@ -126,6 +126,7 @@ class ContentRepositoryMapper implements MetaDataMapperInterface
         $assetNodeTemplate->setName($asset->getIdentifier());
         $this->mapMetaDataToNodeData($assetNodeTemplate, $nodeType, $metaDataCollection);
         $this->nodeService->findOrCreateMetaDataRootNode($this->context)->createNodeFromTemplate($assetNodeTemplate);
+        $this->metaDataRepository->persistEntities();
     }
 
     /**


### PR DESCRIPTION
Since after `assetCreated`, `assetUpdated` gets called, we must persist the newly created meta data node (not only the root node).