### PR TITLE
Add compatability with Flow 7.0 / Neos 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,12 @@
     "type": "neos-package",
     "require": {
         "php": "^7.0",
-        "neos/content-repository": "^3.0 || ^4.0 || ^5.0 || dev-master",
-        "neos/eel": "^4.0 || ^5.0 || ^6.0 || dev-master",
-        "neos/flow": "^4.0 || ^5.0 || ^6.0 || dev-master",
-        "neos/fusion": "^3.0 || ^4.0 || ^5.0 || dev-master",
-        "neos/media": "^3.0 || ^4.0 || ^5.0 || dev-master",
-        "neos/metadata": "^2.0"
+        "neos/content-repository": "^3.0 || ^4.0 || ^5.0 || ^7.0 || dev-master",
+        "neos/eel": "^4.0 || ^5.0 || ^6.0 || ^7.0 || dev-master",
+        "neos/flow": "^4.0 || ^5.0 || ^6.0 || ^7.0 || dev-master",
+        "neos/fusion": "^3.0 || ^4.0 || ^5.0 || ^7.0 || dev-master",
+        "neos/media": "^3.0 || ^4.0 || ^5.0 || ^7.0 || dev-master",
+        "neos/metadata": "^2.0 || dev-master"
     },
     "suggest": {
         "neos/metadata-extractor": "Extracts meta data from Assets"


### PR DESCRIPTION
Just added the required 7.x branches to composer.json

Should I change the PR to allow all future package versions like
```
        "neos/content-repository": ">=3.0 || dev-master",
        "neos/eel": ">=4.0 || dev-master",
        "neos/flow": ">=4.0 || dev-master",
        "neos/fusion": ">=3.0 || dev-master",
        "neos/media": ">=3.0 || dev-master",
```
See https://github.com/neos/metadata/pull/9 for a PR regarding `neos/metadata`