### PR TITLE
BUGFIX: Update dependencies to match php requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Maps asset meta data to CR nodes",
     "type": "neos-package",
     "require": {
-        "php": "^8.0",
+        "php": "^7.4 || ^8.0",
         "neos/content-repository": "^3.0 || ^4.0 || ^5.0 || ^7.0 || ^8.0 || dev-master",
         "neos/eel": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || dev-master",
         "neos/flow": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || dev-master",


### PR DESCRIPTION
This package claims to be compatible with previous Neos versions but the updated php requirements might prevent installations on Neos 7 installations which still have to use PHP 7.

fixes: #11 